### PR TITLE
Don't set conda channel priority to false

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get update && \
     apt-get purge -y --auto-remove curl bzip2 && \
     apt-get clean && \
     conda config --set auto_update_conda true && \
-    conda config --set channel_priority false && \
     if [ "$MINICONDA_VERSION" = "2" ]; then\
         conda install -y futures;\
     fi && \


### PR DESCRIPTION
We used to set that for JupyterHub when installing from conda-forge where it downgraded some packages. Let's cross our fingers and hope this doesn't affect downstream images!